### PR TITLE
Log the exception stack trace

### DIFF
--- a/src/main/java/n64loaderwv/N64Header.java
+++ b/src/main/java/n64loaderwv/N64Header.java
@@ -27,7 +27,7 @@ public class N64Header {
 			gameCode = b.readFixedLenAsciiString(0x3B, 0x4);
 			maskRomVersion = b.readByte(0x3F);
 		} catch (IOException e) {
-			Msg.error(this, e);
+			Msg.trace(this, e);
 		}
 	}
 	

--- a/src/main/java/n64loaderwv/N64LoaderWVLoader.java
+++ b/src/main/java/n64loaderwv/N64LoaderWVLoader.java
@@ -138,7 +138,7 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 				DataUtilities.createData(program, addr, struc, -1, false, ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
 		}
 		catch (AddressOverflowException | CodeUnitInsertionException e) {
-			Msg.error(this, e);
+			Msg.trace(this, e);
 		}
 	}
 	
@@ -207,7 +207,7 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 			}
 		} catch (IOException | InvalidInputException e) 
 		{
-			Msg.error(this, e);
+			Msg.trace(this, e);
 		}
 	}
 


### PR DESCRIPTION
I was initially under the impression the Msg.error would log the stack trace but it doesn't appear to do so. Using Msg.trace logs the exceptions stack trace into the ghidra application.log.