### PR TITLE
Fix RDRAM snapshot sizing and headless options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ credits:
 - [blackgamma7](https://github.com/blackgamma7) for fixing memory layout stuff, adding register symbols and various small changes [see merge commit](https://github.com/zeroKilo/N64LoaderWV/commit/46137048775a41f4b54c08cf3c3fab1bcb962219)
 - [dmattia](https://github.com/dmattia) for adding build instructions for mac
 
-requires JDK 17
+Ghidra 12.1 requires JDK 21. Use the JDK version required by your Ghidra release.
 
 [![Alt text](https://img.youtube.com/vi/3d3a39LuCwc/0.jpg)](https://www.youtube.com/watch?v=3d3a39LuCwc)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,29 @@ this is a loader module for ghidra for N64 roms (.z64, .n64, .v64)
 
 this allows a rom to be labeled, disassembled and decompiled
 
+## Function discovery and runtime-loaded code
+
+The loader creates the N64 memory map and marks the ROM entry point. Ghidra
+then discovers functions reachable through direct references; importing a ROM
+does not prove every function boundary. Code that the game decompresses,
+relocates, or loads as an overlay is not present at its runtime address in the
+initial ROM-to-RAM image.
+
+For those games, capture an RDRAM dump after the code of interest has been
+loaded and select it with the `RDRAM dump file` loader option. Dumps must be
+exactly 4 MiB (base memory) or 8 MiB (Expansion Pak). The loader maps the
+interrupt vectors at `0x80000000` and the remaining bytes at `0x80000400`
+without padding the dump. A dump represents one runtime moment, so overlays
+that reuse an address may require separate projects or snapshots.
+
+The `Signature file` option can also consume an N64sym address/name file or a
+byte-pattern file to seed known functions. These inputs are hints for Ghidra;
+they do not establish that every possible function has been found.
+
+Headless imports can pass the same inputs as `-loader-rdram <path>`,
+`-loader-signature <path>`, `-loader-pif <path>`, and
+`-loader-modem <path>` after selecting `-loader N64LoaderWVLoader`.
+
 credits:
 - [blackgamma7](https://github.com/blackgamma7) for fixing memory layout stuff, adding register symbols and various small changes [see merge commit](https://github.com/zeroKilo/N64LoaderWV/commit/46137048775a41f4b54c08cf3c3fab1bcb962219)
 - [dmattia](https://github.com/dmattia) for adding build instructions for mac

--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,11 @@ tasks.register('testRdramDumpSizing', JavaExec) {
 	mainClass = 'n64loaderwv.RdramDumpSizingTest'
 }
 
-check.dependsOn testRdramDumpSizing
+tasks.register('testLoaderIntegration', JavaExec) {
+	dependsOn verificationClasses
+	classpath = sourceSets.verification.runtimeClasspath
+	mainClass = 'n64loaderwv.LoaderIntegrationTest'
+	systemProperty 'ghidra.install.dir', ghidraInstallDir
+}
+
+check.dependsOn testRdramDumpSizing, testLoaderIntegration

--- a/build.gradle
+++ b/build.gradle
@@ -31,3 +31,18 @@ else {
 	throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
+
+sourceSets {
+	verification {
+		compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+		runtimeClasspath += output + compileClasspath
+	}
+}
+
+tasks.register('testRdramDumpSizing', JavaExec) {
+	dependsOn verificationClasses
+	classpath = sourceSets.verification.runtimeClasspath
+	mainClass = 'n64loaderwv.RdramDumpSizingTest'
+}
+
+check.dependsOn testRdramDumpSizing

--- a/src/main/java/n64loaderwv/N64LoaderWVLoader.java
+++ b/src/main/java/n64loaderwv/N64LoaderWVLoader.java
@@ -62,7 +62,6 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 		}
 	}
 
-	ArrayList<MemoryBlock> blocks = new ArrayList<MemoryBlock>();
 	ArrayList<BlockInfo> initSections = new ArrayList<N64LoaderWVLoader.BlockInfo>() {
 		{			
 			add(new BlockInfo(0xA3F00000, 0xA3F00027, "RDRAM Registers", ".rdreg"));
@@ -129,18 +128,12 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 	}	
 	
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
-			TaskMonitor monitor, MessageLog log) throws IOException {
-		blocks.clear();
-		try {
-			loadProgram(provider, loadSpec, options, program, monitor, log);
-		} finally {
-			// MemoryBlock instances belong to this Program and must not survive an import.
-			blocks.clear();
-		}
+			TaskMonitor monitor, MessageLog log) throws IOException, CancelledException {
+		loadProgram(provider, loadSpec, options, program, monitor, log);
 	}
 
 	private void loadProgram(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
-			TaskMonitor monitor, MessageLog log) throws IOException {
+			TaskMonitor monitor, MessageLog log) throws IOException, CancelledException {
 		Msg.info(this, "N64 Loader: Checking Endianess");
 		byte[] data;
 		BinaryReader br = new BinaryReader(provider, false);
@@ -245,128 +238,128 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 			bapModemROM.close();
 		}
 		try {
-			Address addr = MakeAddress(0x1FC00000L);
+			Address addr = MakeAddress(program, 0x1FC00000L);
 			if (addr != null) {
 				program.getSymbolTable().addExternalEntryPoint(addr);
 				program.getSymbolTable().createLabel(addr, "pifMain", SourceType.ANALYSIS);
 			}
-			addr = MakeAddress(0xA4000040L);
+			addr = MakeAddress(program, 0xA4000040L);
 			if (addr != null) {
 				program.getSymbolTable().addExternalEntryPoint(addr);
 				program.getSymbolTable().createLabel(addr, "bootMain", SourceType.ANALYSIS);
 			}
-			addr = MakeAddress(h.loadAddress);
+			addr = MakeAddress(program, h.loadAddress);
 			if (addr != null) {
 				program.getSymbolTable().addExternalEntryPoint(addr);
 				program.getSymbolTable().createLabel(addr, "ramMain", SourceType.ANALYSIS);
 			}
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00000L), "RDRAM_CONFIG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00004L), "RDRAM_DEVICE_ID", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00008L), "RDRAM_DELAY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f0000CL), "RDRAM_MODE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00010L), "RDRAM_REF_INTERVAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00014L), "RDRAM_REF_ROW", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00018L), "RDRAM_RAS_INTERVAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f0001CL), "RDRAM_MIN_INTERVAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00020L), "RDRAM_ADDR_SELECT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA3f00024L), "RDRAM_DEVICE_MANUF", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4040000L), "SP_MEM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4040004L), "SP_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4040008L), "SP_RD_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA404000CL), "SP_WR_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4040010L), "SP_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4040014L), "SP_DMA_FULL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4040018L), "SP_DMA_BUSY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA404001CL), "SP_SEMAPHORE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4080000L), "SP_PC", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4100000L), "DCP_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4100004L), "DCP_END", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4100008L), "DCP_CURRENT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA410000cL), "DCP_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4100010L), "DCP_CLOCK", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4100014L), "DCP_BUFBUSY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4100018L), "DCP_PIPEBUSY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA410001cL), "DCP_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4300000L), "MI_INIT_MODE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4300004L), "MI_VERSION", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4300008L), "MI_INTR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA430000CL), "MI_INTR_MASK", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400000L), "VI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400004L), "VI_ORIGIN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400008L), "VI_WIDTH", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA440000CL), "VI_INTR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400010L), "VI_CURRENT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400014L), "VI_BURST", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400018L), "VI_V_SYNC", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA440001CL), "VI_H_SYNC", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400020L), "VI_LEAP", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400024L), "VI_H_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400028L), "VI_V_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA440002CL), "VI_V_BURST", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400030L), "VI_X_SCALE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4400034L), "VI_Y_SCALE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4500000L), "AI_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4500004L), "AI_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4500008L), "AI_CONTROL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA450000CL), "AI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4500010L), "AI_DACRATE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4500014L), "AI_BITRATE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600000L), "PI_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600004L), "PI_CART_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600008L), "PI_RD_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA460000CL), "PI_WR_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600010L), "PI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600014L), "PI_BSD_DOM1_LAT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600018L), "PI_BSD_DOM1_PWD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA460001CL), "PI_BSD_DOM1_PGS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600020L), "PI_BSD_DOM1_RLS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600024L), "PI_BSD_DOM2_LAT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600028L), "PI_BSD_DOM2_PWD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA460002CL), "PI_BSD_DOM2_PGS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4600030L), "PI_BSD_DOM2_RLS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4700000L), "RI_MODE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4700004L), "RI_CONFIG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4700008L), "RI_CURRENT_LOAD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA470000CL), "RI_SELECT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4700010L), "RI_REFRESH", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4700014L), "RI_LATENCY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4700018L), "RI_RERROR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA470001CL), "RI_WERROR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4800000L), "SI_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4800004L), "SI_PIF_ADDR_RD64B_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4800010L), "SI_PIF_ADDR_WR64B_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA4800018L), "SI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000500L), "ASIC_DATA", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000504L), "ASIC_MISC_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000508L), "ASIC_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA500050CL), "ASIC_CUR_TK", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000510L), "ASIC_BM_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000514L), "ASIC_ERR_SECTOR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000518L), "ASIC_SEQ_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA500051CL), "ASIC_CUR_SECTOR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000520L), "ASIC_HARD_RESET", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000524L), "ASIC_C1_SO", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000528L), "ASIC_HOST_SECBYTE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA500052CL), "ASIC_C1_S2", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000530L), "ASIC_SEC_BYTE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000534L), "ASIC_C1_S4", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000538L), "ASIC_C1_S6", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA500053CL), "ASIC_CUR_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000540L), "ASIC_ID_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000544L), "ASIC_TEST_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0xA5000548L), "ASIC_TEST_PIN_SEL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000000L), "TLB_REFILL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000080L), "XTLB_REFILL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000100L), "CACHE_ERROR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000180L), "GEN_EXCEPTION", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000300L), "NTSC_PAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000304L), "CART_DD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000308L), "ROM_BASE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x8000030cL), "RESET", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000310L), "CIC_ID", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000314L), "VERSION", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x80000318L), "RDRAM_SIZE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(0x8000031cL), "NMI_BUFFER", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00000L), "RDRAM_CONFIG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00004L), "RDRAM_DEVICE_ID", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00008L), "RDRAM_DELAY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f0000CL), "RDRAM_MODE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00010L), "RDRAM_REF_INTERVAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00014L), "RDRAM_REF_ROW", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00018L), "RDRAM_RAS_INTERVAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f0001CL), "RDRAM_MIN_INTERVAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00020L), "RDRAM_ADDR_SELECT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00024L), "RDRAM_DEVICE_MANUF", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040000L), "SP_MEM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040004L), "SP_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040008L), "SP_RD_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA404000CL), "SP_WR_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040010L), "SP_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040014L), "SP_DMA_FULL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040018L), "SP_DMA_BUSY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA404001CL), "SP_SEMAPHORE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4080000L), "SP_PC", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100000L), "DCP_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100004L), "DCP_END", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100008L), "DCP_CURRENT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA410000cL), "DCP_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100010L), "DCP_CLOCK", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100014L), "DCP_BUFBUSY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100018L), "DCP_PIPEBUSY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA410001cL), "DCP_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4300000L), "MI_INIT_MODE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4300004L), "MI_VERSION", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4300008L), "MI_INTR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA430000CL), "MI_INTR_MASK", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400000L), "VI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400004L), "VI_ORIGIN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400008L), "VI_WIDTH", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA440000CL), "VI_INTR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400010L), "VI_CURRENT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400014L), "VI_BURST", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400018L), "VI_V_SYNC", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA440001CL), "VI_H_SYNC", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400020L), "VI_LEAP", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400024L), "VI_H_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400028L), "VI_V_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA440002CL), "VI_V_BURST", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400030L), "VI_X_SCALE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400034L), "VI_Y_SCALE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500000L), "AI_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500004L), "AI_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500008L), "AI_CONTROL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA450000CL), "AI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500010L), "AI_DACRATE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500014L), "AI_BITRATE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600000L), "PI_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600004L), "PI_CART_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600008L), "PI_RD_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA460000CL), "PI_WR_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600010L), "PI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600014L), "PI_BSD_DOM1_LAT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600018L), "PI_BSD_DOM1_PWD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA460001CL), "PI_BSD_DOM1_PGS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600020L), "PI_BSD_DOM1_RLS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600024L), "PI_BSD_DOM2_LAT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600028L), "PI_BSD_DOM2_PWD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA460002CL), "PI_BSD_DOM2_PGS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600030L), "PI_BSD_DOM2_RLS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700000L), "RI_MODE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700004L), "RI_CONFIG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700008L), "RI_CURRENT_LOAD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA470000CL), "RI_SELECT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700010L), "RI_REFRESH", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700014L), "RI_LATENCY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700018L), "RI_RERROR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA470001CL), "RI_WERROR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800000L), "SI_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800004L), "SI_PIF_ADDR_RD64B_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800010L), "SI_PIF_ADDR_WR64B_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800018L), "SI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000500L), "ASIC_DATA", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000504L), "ASIC_MISC_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000508L), "ASIC_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500050CL), "ASIC_CUR_TK", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000510L), "ASIC_BM_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000514L), "ASIC_ERR_SECTOR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000518L), "ASIC_SEQ_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500051CL), "ASIC_CUR_SECTOR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000520L), "ASIC_HARD_RESET", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000524L), "ASIC_C1_SO", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000528L), "ASIC_HOST_SECBYTE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500052CL), "ASIC_C1_S2", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000530L), "ASIC_SEC_BYTE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000534L), "ASIC_C1_S4", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000538L), "ASIC_C1_S6", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500053CL), "ASIC_CUR_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000540L), "ASIC_ID_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000544L), "ASIC_TEST_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000548L), "ASIC_TEST_PIN_SEL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000000L), "TLB_REFILL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000080L), "XTLB_REFILL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000100L), "CACHE_ERROR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000180L), "GEN_EXCEPTION", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000300L), "NTSC_PAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000304L), "CART_DD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000308L), "ROM_BASE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x8000030cL), "RESET", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000310L), "CIC_ID", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000314L), "VERSION", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000318L), "RDRAM_SIZE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(program, 0x8000031cL), "NMI_BUFFER", SourceType.ANALYSIS);
 		} catch (Exception ex) {
 		}
 
@@ -374,18 +367,22 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 	}
 
 	public void MakeBlock(Program program, String name, String desc, long address, InputStream s, int size,
-			String flags, Structure struc, MessageLog log, TaskMonitor monitor) throws IOException {
+			String flags, Structure struc, MessageLog log, TaskMonitor monitor)
+			throws IOException, CancelledException {
 		try {
 			byte[] bf = flags.getBytes();
 			Address addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(address);
 			MemoryBlock block = MemoryBlockUtils.createInitializedBlock(program, false, name, addr, s, size, desc, null,
 					bf[0] == '1', bf[1] == '1', bf[2] == '1', log, monitor);
-			if (block == null)
-				throw new IOException("block creation was cancelled");
-			blocks.add(block);
+			if (block == null) {
+				monitor.checkCancelled();
+				throw new IOException("block creation returned no memory block");
+			}
 			if (struc != null)
 				DataUtilities.createData(program, block.getStart(), struc, -1, false,
 						ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
+		} catch (CancelledException e) {
+			throw e;
 		} catch (Exception e) {
 			throw new IOException("N64 Loader: failed to create block " + name, e);
 		}
@@ -399,15 +396,11 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 		return (int) length;
 	}
 
-	public Address MakeAddress(long address) {
-		for (MemoryBlock block : blocks) {
-			if (address >= block.getStart().getAddressableWordOffset()
-					&& address <= block.getEnd().getAddressableWordOffset()) {
-				Address addr = block.getStart();
-				return addr.add(address - addr.getAddressableWordOffset());
-			}
-		}
-		return null;
+	public Address MakeAddress(Program program, long address) {
+		// Loader instances may serve overlapping imports: import A must not clear or
+		// populate address state used while import B resolves symbols.
+		Address result = program.getAddressFactory().getDefaultAddressSpace().getAddress(address);
+		return program.getMemory().getBlock(result) == null ? null : result;
 	}
 
 	public void MixedSwap(byte[] buff) {
@@ -441,7 +434,7 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 			long address = Long.parseLong(parts[0], 16);
 			String name = parts[1];
 			if (address >= loadAddress) {
-				SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, MakeAddress(address), null, name,
+				SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, MakeAddress(program, address), null, name,
 						SourceType.ANALYSIS);
 				Msg.info(this, "N64 Loader: Loaded Symbol at " + String.format("0x%08X", address) + " Name=" + name);
 			}
@@ -473,7 +466,7 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 				SigPattern sig = patterns.get(j);
 				if (sig.Match(rom, i)) {
 					long address = loadAddress + i - 0x1000;
-					Address addr = MakeAddress(address);
+					Address addr = MakeAddress(program, address);
 					if (addr != null) {
 						SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, addr, null, sig.name,
 								SourceType.ANALYSIS);

--- a/src/main/java/n64loaderwv/N64LoaderWVLoader.java
+++ b/src/main/java/n64loaderwv/N64LoaderWVLoader.java
@@ -21,8 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
 import ghidra.app.util.MemoryBlockUtils;
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.BinaryReader;
@@ -31,6 +29,7 @@ import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.app.util.opinion.AbstractLibrarySupportLoader;
 import ghidra.app.util.opinion.LoadSpec;
+import ghidra.app.util.opinion.Loader;
 import ghidra.framework.model.DomainObject;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.data.DataUtilities;
@@ -47,6 +46,9 @@ import ghidra.util.exception.InvalidInputException;
 import ghidra.util.task.TaskMonitor;
 
 public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
+	static final int BASE_RDRAM_SIZE = 4 * 1024 * 1024;
+	static final int EXPANDED_RDRAM_SIZE = 8 * 1024 * 1024;
+	static final int INTERRUPT_VECTOR_SIZE = 0x400;
 
 	class BlockInfo {
 		long start, end;
@@ -128,6 +130,17 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 	
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
 			TaskMonitor monitor, MessageLog log) throws IOException {
+		blocks.clear();
+		try {
+			loadProgram(provider, loadSpec, options, program, monitor, log);
+		} finally {
+			// MemoryBlock instances belong to this Program and must not survive an import.
+			blocks.clear();
+		}
+	}
+
+	private void loadProgram(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
+			TaskMonitor monitor, MessageLog log) throws IOException {
 		Msg.info(this, "N64 Loader: Checking Endianess");
 		byte[] data;
 		BinaryReader br = new BinaryReader(provider, false);
@@ -150,12 +163,23 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 		ByteArrayProvider bapROM = new ByteArrayProvider(buffROM);
 		Msg.info(this, "N64 Loader: Loading header");
 		N64Header h = new N64Header(buffROM);
+		ByteArrayProvider bapRDRAM = null;
+		if (!((String) options.get(3).getValue()).isEmpty()) {
+			String filePath = (String) options.get(3).getValue();
+			long fileSize = Files.size(Paths.get(filePath));
+			int dumpSize = checkedRdramDumpLength(fileSize);
+			data = Files.readAllBytes(Paths.get(filePath));
+			if (data.length != dumpSize)
+				throw new IOException("RDRAM dump changed while it was being read");
+			bapRDRAM = new ByteArrayProvider(data);
+		}
 
 		for (BlockInfo bli : initSections) {
 			long size = (bli.end + 1) - bli.start;
 			monitor.setMessage("N64 Loader: Creating segment " + bli.name);
 			Msg.info(this, "N64 Loader: Creating segment " + bli.name);
 			ByteArrayProvider bapBlock = new ByteArrayProvider(new byte[(int) size]);
+			boolean borrowedRdram = false;
 			if (bli.desc.equals(".pifrom")) {
 				if (!((String) options.get(2).getValue()).isEmpty()) {
 					String filePath = (String) options.get(2).getValue();
@@ -165,15 +189,15 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 				bapBlock.close();
 				bapBlock = new ByteArrayProvider(data);
 			}
-			if (bli.desc.equals(".ivt") && !((String) options.get(3).getValue()).isEmpty()) {
-				String filePath = (String) options.get(3).getValue();
-				data = Arrays.copyOfRange(Files.readAllBytes(Paths.get(filePath)), 0, 0x400);
+			if (bli.desc.equals(".ivt") && bapRDRAM != null) {
 				bapBlock.close();
-				bapBlock = new ByteArrayProvider(data);
+				bapBlock = bapRDRAM;
+				borrowedRdram = true;
 			}
 			MakeBlock(program, bli.desc, bli.name, bli.start, bapBlock.getInputStream(0), (int) size, "111", null, log,
 					monitor);
-			bapBlock.close();
+			if (!borrowedRdram)
+				bapBlock.close();
 		}
 
 		Msg.info(this, "N64 Loader: Creating segment ROM");
@@ -186,12 +210,10 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 				monitor);
 
 		Msg.info(this, "N64 Loader: Creating segment RAM");
-		if(!((String) options.get(3).getValue()).isEmpty()) {
-			String filePath = (String) options.get(3).getValue();
-			data = Arrays.copyOfRange(Files.readAllBytes(Paths.get(filePath)), 0x400, 0x3F00000);
-			ByteArrayProvider bapRAM = new ByteArrayProvider(data);
-			MakeBlock(program, ".ram", "RAM content", 0x80000400, bapRAM.getInputStream(0), 0x3F00000 - 0x400, "111", null, log, monitor);
-			bapRAM.close();
+		if (bapRDRAM != null) {
+			MakeBlock(program, ".ram", "RAM content", 0x80000400, bapRDRAM.getInputStream(INTERRUPT_VECTOR_SIZE),
+					(int) bapRDRAM.length() - INTERRUPT_VECTOR_SIZE, "111", null, log, monitor);
+			bapRDRAM.close();
 		}
 		else
 			MakeBlock(program, ".ram", "RAM content", h.loadAddress, bapROM.getInputStream(0x1000), buffROM.length - 0x1000, "111", null, log, monitor);
@@ -352,19 +374,29 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 	}
 
 	public void MakeBlock(Program program, String name, String desc, long address, InputStream s, int size,
-			String flags, Structure struc, MessageLog log, TaskMonitor monitor) {
+			String flags, Structure struc, MessageLog log, TaskMonitor monitor) throws IOException {
 		try {
 			byte[] bf = flags.getBytes();
 			Address addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(address);
 			MemoryBlock block = MemoryBlockUtils.createInitializedBlock(program, false, name, addr, s, size, desc, null,
 					bf[0] == '1', bf[1] == '1', bf[2] == '1', log, monitor);
+			if (block == null)
+				throw new IOException("block creation was cancelled");
 			blocks.add(block);
 			if (struc != null)
 				DataUtilities.createData(program, block.getStart(), struc, -1, false,
 						ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
 		} catch (Exception e) {
-			Msg.error(this, ExceptionUtils.getStackTrace(e));
+			throw new IOException("N64 Loader: failed to create block " + name, e);
 		}
+	}
+
+	static int checkedRdramDumpLength(long length) throws IOException {
+		if (length != BASE_RDRAM_SIZE && length != EXPANDED_RDRAM_SIZE) {
+			throw new IOException(String.format(
+					"RDRAM dump must be exactly 4 MiB or 8 MiB, got %d bytes", length));
+		}
+		return (int) length;
 	}
 
 	public Address MakeAddress(long address) {
@@ -457,10 +489,14 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 	@Override
 	public List<Option> getDefaultOptions(ByteProvider provider, LoadSpec loadSpec,	DomainObject domainObject, boolean loadIntoProgram, boolean mirrorFsLayout) {
 		List<Option> list = new ArrayList<Option>();
-		list.add(new Option("Signature file", ""));
-		list.add(new Option("Modem.bin file", ""));
-		list.add(new Option("PIF file", ""));
-		list.add(new Option("RDRAM dump file", ""));
+		list.add(new Option("Signature file", "", String.class,
+				Loader.COMMAND_LINE_ARG_PREFIX + "-signature"));
+		list.add(new Option("Modem.bin file", "", String.class,
+				Loader.COMMAND_LINE_ARG_PREFIX + "-modem"));
+		list.add(new Option("PIF file", "", String.class,
+				Loader.COMMAND_LINE_ARG_PREFIX + "-pif"));
+		list.add(new Option("RDRAM dump file", "", String.class,
+				Loader.COMMAND_LINE_ARG_PREFIX + "-rdram"));
 		return list;
 	}
 

--- a/src/main/java/n64loaderwv/N64LoaderWVLoader.java
+++ b/src/main/java/n64loaderwv/N64LoaderWVLoader.java
@@ -18,6 +18,7 @@ package n64loaderwv;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 
@@ -32,6 +33,7 @@ import ghidra.app.util.opinion.LoadSpec;
 import ghidra.app.util.opinion.Loader;
 import ghidra.framework.model.DomainObject;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.data.DataUtilities;
 import ghidra.program.model.data.Structure;
 import ghidra.program.model.data.DataUtilities.ClearDataMode;
@@ -49,6 +51,32 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 	static final int BASE_RDRAM_SIZE = 4 * 1024 * 1024;
 	static final int EXPANDED_RDRAM_SIZE = 8 * 1024 * 1024;
 	static final int INTERRUPT_VECTOR_SIZE = 0x400;
+
+	static final class ImportContext {
+		private final AddressSpace defaultAddressSpace;
+		private final List<MemoryBlock> blocks = new ArrayList<>();
+
+		ImportContext(Program program) {
+			defaultAddressSpace = program.getAddressFactory().getDefaultAddressSpace();
+		}
+
+		Address defaultAddress(long offset) {
+			return defaultAddressSpace.getAddress(offset);
+		}
+
+		void add(MemoryBlock block) {
+			blocks.add(block);
+		}
+
+		Address resolve(long offset) {
+			for (MemoryBlock block : blocks) {
+				Address candidate = block.getStart().getAddressSpace().getAddress(offset);
+				if (block.contains(candidate))
+					return candidate;
+			}
+			return null;
+		}
+	}
 
 	class BlockInfo {
 		long start, end;
@@ -134,6 +162,7 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 
 	private void loadProgram(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
 			TaskMonitor monitor, MessageLog log) throws IOException, CancelledException {
+		ImportContext context = new ImportContext(program);
 		Msg.info(this, "N64 Loader: Checking Endianess");
 		byte[] data;
 		BinaryReader br = new BinaryReader(provider, false);
@@ -158,12 +187,8 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 		N64Header h = new N64Header(buffROM);
 		ByteArrayProvider bapRDRAM = null;
 		if (!((String) options.get(3).getValue()).isEmpty()) {
-			String filePath = (String) options.get(3).getValue();
-			long fileSize = Files.size(Paths.get(filePath));
-			int dumpSize = checkedRdramDumpLength(fileSize);
-			data = Files.readAllBytes(Paths.get(filePath));
-			if (data.length != dumpSize)
-				throw new IOException("RDRAM dump changed while it was being read");
+			Path filePath = Paths.get((String) options.get(3).getValue());
+			data = readRdramDump(filePath);
 			bapRDRAM = new ByteArrayProvider(data);
 		}
 
@@ -187,29 +212,31 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 				bapBlock = bapRDRAM;
 				borrowedRdram = true;
 			}
-			MakeBlock(program, bli.desc, bli.name, bli.start, bapBlock.getInputStream(0), (int) size, "111", null, log,
-					monitor);
+			MakeBlock(context, program, bli.desc, bli.name, bli.start, bapBlock.getInputStream(0), (int) size, "111",
+					null, log, monitor);
 			if (!borrowedRdram)
 				bapBlock.close();
 		}
 
 		Msg.info(this, "N64 Loader: Creating segment ROM");
 		Structure header_struct = N64Header.getDataStructure();
-		MakeBlock(program, ".rom", "ROM image", 0xB0000000, bapROM.getInputStream(0), (int) bapROM.length(), "100",
-				header_struct, log, monitor);
+		MakeBlock(context, program, ".rom", "ROM image", 0xB0000000, bapROM.getInputStream(0),
+				(int) bapROM.length(), "100", header_struct, log, monitor);
 
 		Msg.info(this, "N64 Loader: Creating segment BOOT");
-		MakeBlock(program, ".boot", "ROM bootloader", 0xA4000040, bapROM.getInputStream(0x40), 0xFC0, "111", null, log,
-				monitor);
+		MakeBlock(context, program, ".boot", "ROM bootloader", 0xA4000040, bapROM.getInputStream(0x40), 0xFC0,
+				"111", null, log, monitor);
 
 		Msg.info(this, "N64 Loader: Creating segment RAM");
 		if (bapRDRAM != null) {
-			MakeBlock(program, ".ram", "RAM content", 0x80000400, bapRDRAM.getInputStream(INTERRUPT_VECTOR_SIZE),
-					(int) bapRDRAM.length() - INTERRUPT_VECTOR_SIZE, "111", null, log, monitor);
+			MakeBlock(context, program, ".ram", "RAM content", 0x80000400,
+					bapRDRAM.getInputStream(INTERRUPT_VECTOR_SIZE),
+					rdramRamLength((int) bapRDRAM.length()), "111", null, log, monitor);
 			bapRDRAM.close();
 		}
 		else
-			MakeBlock(program, ".ram", "RAM content", h.loadAddress, bapROM.getInputStream(0x1000), buffROM.length - 0x1000, "111", null, log, monitor);
+			MakeBlock(context, program, ".ram", "RAM content", h.loadAddress, bapROM.getInputStream(0x1000),
+					buffROM.length - 0x1000, "111", null, log, monitor);
 
 		bapROM.close();
 
@@ -217,13 +244,13 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 			String filePath = (String) options.get(0).getValue();
 			boolean done = false;
 			try {
-				ScanPatterns(buffROM, h.loadAddress, filePath, program, monitor);
+				ScanPatterns(context, buffROM, h.loadAddress, filePath, program, monitor);
 				done = true;
 			} catch (Exception ex) {
 			}
 			if (!done) {
 				try {
-					ApplyN64sym(buffROM, h.loadAddress, filePath, program, monitor);
+					ApplyN64sym(context, buffROM, h.loadAddress, filePath, program, monitor);
 					done = true;
 				} catch (Exception ex) {
 				}
@@ -234,150 +261,152 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 			String filePath = (String) options.get(1).getValue();
 			byte[] modem_rom = Files.readAllBytes(Paths.get(filePath));
 			ByteArrayProvider bapModemROM = new ByteArrayProvider(modem_rom);
-			MakeBlock(program, ".modem", "Modem ROM image", 0xB8000000, bapModemROM.getInputStream(0), modem_rom.length, "100", null, log, monitor);
+			MakeBlock(context, program, ".modem", "Modem ROM image", 0xB8000000, bapModemROM.getInputStream(0),
+					modem_rom.length, "100", null, log, monitor);
 			bapModemROM.close();
 		}
 		try {
-			Address addr = MakeAddress(program, 0x1FC00000L);
+			Address addr = MakeAddress(context, 0x1FC00000L);
 			if (addr != null) {
 				program.getSymbolTable().addExternalEntryPoint(addr);
 				program.getSymbolTable().createLabel(addr, "pifMain", SourceType.ANALYSIS);
 			}
-			addr = MakeAddress(program, 0xA4000040L);
+			addr = MakeAddress(context, 0xA4000040L);
 			if (addr != null) {
 				program.getSymbolTable().addExternalEntryPoint(addr);
 				program.getSymbolTable().createLabel(addr, "bootMain", SourceType.ANALYSIS);
 			}
-			addr = MakeAddress(program, h.loadAddress);
+			addr = MakeAddress(context, h.loadAddress);
 			if (addr != null) {
 				program.getSymbolTable().addExternalEntryPoint(addr);
 				program.getSymbolTable().createLabel(addr, "ramMain", SourceType.ANALYSIS);
 			}
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00000L), "RDRAM_CONFIG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00004L), "RDRAM_DEVICE_ID", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00008L), "RDRAM_DELAY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f0000CL), "RDRAM_MODE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00010L), "RDRAM_REF_INTERVAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00014L), "RDRAM_REF_ROW", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00018L), "RDRAM_RAS_INTERVAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f0001CL), "RDRAM_MIN_INTERVAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00020L), "RDRAM_ADDR_SELECT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA3f00024L), "RDRAM_DEVICE_MANUF", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040000L), "SP_MEM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040004L), "SP_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040008L), "SP_RD_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA404000CL), "SP_WR_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040010L), "SP_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040014L), "SP_DMA_FULL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4040018L), "SP_DMA_BUSY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA404001CL), "SP_SEMAPHORE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4080000L), "SP_PC", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100000L), "DCP_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100004L), "DCP_END", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100008L), "DCP_CURRENT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA410000cL), "DCP_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100010L), "DCP_CLOCK", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100014L), "DCP_BUFBUSY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4100018L), "DCP_PIPEBUSY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA410001cL), "DCP_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4300000L), "MI_INIT_MODE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4300004L), "MI_VERSION", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4300008L), "MI_INTR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA430000CL), "MI_INTR_MASK", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400000L), "VI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400004L), "VI_ORIGIN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400008L), "VI_WIDTH", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA440000CL), "VI_INTR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400010L), "VI_CURRENT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400014L), "VI_BURST", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400018L), "VI_V_SYNC", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA440001CL), "VI_H_SYNC", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400020L), "VI_LEAP", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400024L), "VI_H_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400028L), "VI_V_START", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA440002CL), "VI_V_BURST", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400030L), "VI_X_SCALE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4400034L), "VI_Y_SCALE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500000L), "AI_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500004L), "AI_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500008L), "AI_CONTROL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA450000CL), "AI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500010L), "AI_DACRATE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4500014L), "AI_BITRATE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600000L), "PI_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600004L), "PI_CART_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600008L), "PI_RD_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA460000CL), "PI_WR_LEN", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600010L), "PI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600014L), "PI_BSD_DOM1_LAT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600018L), "PI_BSD_DOM1_PWD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA460001CL), "PI_BSD_DOM1_PGS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600020L), "PI_BSD_DOM1_RLS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600024L), "PI_BSD_DOM2_LAT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600028L), "PI_BSD_DOM2_PWD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA460002CL), "PI_BSD_DOM2_PGS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4600030L), "PI_BSD_DOM2_RLS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700000L), "RI_MODE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700004L), "RI_CONFIG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700008L), "RI_CURRENT_LOAD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA470000CL), "RI_SELECT", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700010L), "RI_REFRESH", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700014L), "RI_LATENCY", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4700018L), "RI_RERROR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA470001CL), "RI_WERROR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800000L), "SI_DRAM_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800004L), "SI_PIF_ADDR_RD64B_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800010L), "SI_PIF_ADDR_WR64B_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA4800018L), "SI_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000500L), "ASIC_DATA", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000504L), "ASIC_MISC_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000508L), "ASIC_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500050CL), "ASIC_CUR_TK", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000510L), "ASIC_BM_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000514L), "ASIC_ERR_SECTOR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000518L), "ASIC_SEQ_STATUS", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500051CL), "ASIC_CUR_SECTOR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000520L), "ASIC_HARD_RESET", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000524L), "ASIC_C1_SO", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000528L), "ASIC_HOST_SECBYTE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500052CL), "ASIC_C1_S2", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000530L), "ASIC_SEC_BYTE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000534L), "ASIC_C1_S4", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000538L), "ASIC_C1_S6", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA500053CL), "ASIC_CUR_ADDR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000540L), "ASIC_ID_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000544L), "ASIC_TEST_REG", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0xA5000548L), "ASIC_TEST_PIN_SEL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000000L), "TLB_REFILL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000080L), "XTLB_REFILL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000100L), "CACHE_ERROR", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000180L), "GEN_EXCEPTION", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000300L), "NTSC_PAL", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000304L), "CART_DD", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000308L), "ROM_BASE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x8000030cL), "RESET", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000310L), "CIC_ID", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000314L), "VERSION", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x80000318L), "RDRAM_SIZE", SourceType.ANALYSIS);
-			program.getSymbolTable().createLabel(MakeAddress(program, 0x8000031cL), "NMI_BUFFER", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00000L), "RDRAM_CONFIG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00004L), "RDRAM_DEVICE_ID", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00008L), "RDRAM_DELAY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f0000CL), "RDRAM_MODE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00010L), "RDRAM_REF_INTERVAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00014L), "RDRAM_REF_ROW", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00018L), "RDRAM_RAS_INTERVAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f0001CL), "RDRAM_MIN_INTERVAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00020L), "RDRAM_ADDR_SELECT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA3f00024L), "RDRAM_DEVICE_MANUF", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4040000L), "SP_MEM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4040004L), "SP_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4040008L), "SP_RD_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA404000CL), "SP_WR_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4040010L), "SP_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4040014L), "SP_DMA_FULL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4040018L), "SP_DMA_BUSY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA404001CL), "SP_SEMAPHORE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4080000L), "SP_PC", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4100000L), "DCP_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4100004L), "DCP_END", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4100008L), "DCP_CURRENT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA410000cL), "DCP_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4100010L), "DCP_CLOCK", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4100014L), "DCP_BUFBUSY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4100018L), "DCP_PIPEBUSY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA410001cL), "DCP_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4300000L), "MI_INIT_MODE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4300004L), "MI_VERSION", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4300008L), "MI_INTR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA430000CL), "MI_INTR_MASK", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400000L), "VI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400004L), "VI_ORIGIN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400008L), "VI_WIDTH", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA440000CL), "VI_INTR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400010L), "VI_CURRENT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400014L), "VI_BURST", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400018L), "VI_V_SYNC", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA440001CL), "VI_H_SYNC", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400020L), "VI_LEAP", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400024L), "VI_H_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400028L), "VI_V_START", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA440002CL), "VI_V_BURST", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400030L), "VI_X_SCALE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4400034L), "VI_Y_SCALE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4500000L), "AI_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4500004L), "AI_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4500008L), "AI_CONTROL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA450000CL), "AI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4500010L), "AI_DACRATE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4500014L), "AI_BITRATE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600000L), "PI_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600004L), "PI_CART_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600008L), "PI_RD_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA460000CL), "PI_WR_LEN", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600010L), "PI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600014L), "PI_BSD_DOM1_LAT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600018L), "PI_BSD_DOM1_PWD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA460001CL), "PI_BSD_DOM1_PGS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600020L), "PI_BSD_DOM1_RLS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600024L), "PI_BSD_DOM2_LAT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600028L), "PI_BSD_DOM2_PWD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA460002CL), "PI_BSD_DOM2_PGS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4600030L), "PI_BSD_DOM2_RLS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4700000L), "RI_MODE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4700004L), "RI_CONFIG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4700008L), "RI_CURRENT_LOAD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA470000CL), "RI_SELECT", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4700010L), "RI_REFRESH", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4700014L), "RI_LATENCY", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4700018L), "RI_RERROR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA470001CL), "RI_WERROR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4800000L), "SI_DRAM_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4800004L), "SI_PIF_ADDR_RD64B_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4800010L), "SI_PIF_ADDR_WR64B_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA4800018L), "SI_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000500L), "ASIC_DATA", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000504L), "ASIC_MISC_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000508L), "ASIC_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA500050CL), "ASIC_CUR_TK", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000510L), "ASIC_BM_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000514L), "ASIC_ERR_SECTOR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000518L), "ASIC_SEQ_STATUS", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA500051CL), "ASIC_CUR_SECTOR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000520L), "ASIC_HARD_RESET", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000524L), "ASIC_C1_SO", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000528L), "ASIC_HOST_SECBYTE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA500052CL), "ASIC_C1_S2", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000530L), "ASIC_SEC_BYTE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000534L), "ASIC_C1_S4", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000538L), "ASIC_C1_S6", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA500053CL), "ASIC_CUR_ADDR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000540L), "ASIC_ID_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000544L), "ASIC_TEST_REG", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0xA5000548L), "ASIC_TEST_PIN_SEL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000000L), "TLB_REFILL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000080L), "XTLB_REFILL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000100L), "CACHE_ERROR", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000180L), "GEN_EXCEPTION", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000300L), "NTSC_PAL", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000304L), "CART_DD", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000308L), "ROM_BASE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x8000030cL), "RESET", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000310L), "CIC_ID", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000314L), "VERSION", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x80000318L), "RDRAM_SIZE", SourceType.ANALYSIS);
+			program.getSymbolTable().createLabel(MakeAddress(context, 0x8000031cL), "NMI_BUFFER", SourceType.ANALYSIS);
 		} catch (Exception ex) {
 		}
 
 		Msg.info(this, "N64 Loader: Done Loading");
 	}
 
-	public void MakeBlock(Program program, String name, String desc, long address, InputStream s, int size,
+	public void MakeBlock(ImportContext context, Program program, String name, String desc, long address, InputStream s, int size,
 			String flags, Structure struc, MessageLog log, TaskMonitor monitor)
 			throws IOException, CancelledException {
 		try {
 			byte[] bf = flags.getBytes();
-			Address addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(address);
+			Address addr = context.defaultAddress(address);
 			MemoryBlock block = MemoryBlockUtils.createInitializedBlock(program, false, name, addr, s, size, desc, null,
 					bf[0] == '1', bf[1] == '1', bf[2] == '1', log, monitor);
 			if (block == null) {
 				monitor.checkCancelled();
 				throw new IOException("block creation returned no memory block");
 			}
+			context.add(block);
 			if (struc != null)
 				DataUtilities.createData(program, block.getStart(), struc, -1, false,
 						ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
@@ -394,6 +423,22 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 					"RDRAM dump must be exactly 4 MiB or 8 MiB, got %d bytes", length));
 		}
 		return (int) length;
+	}
+
+	static byte[] readRdramDump(Path path) throws IOException {
+		try (InputStream input = Files.newInputStream(path)) {
+			byte[] data = input.readNBytes(EXPANDED_RDRAM_SIZE + 1);
+			checkedRdramDumpLength(data.length);
+			return data;
+		}
+	}
+
+	static int rdramRamLength(int dumpLength) throws IOException {
+		return checkedRdramDumpLength(dumpLength) - INTERRUPT_VECTOR_SIZE;
+	}
+
+	Address MakeAddress(ImportContext context, long address) {
+		return context.resolve(address);
 	}
 
 	public Address MakeAddress(Program program, long address) {
@@ -423,7 +468,8 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 		buff[b] = t;
 	}
 
-	public void ApplyN64sym(byte[] rom, long loadAddress, String sigPath, Program program, TaskMonitor monitor)
+	public void ApplyN64sym(ImportContext context, byte[] rom, long loadAddress, String sigPath, Program program,
+			TaskMonitor monitor)
 			throws IOException, InvalidInputException {
 		Msg.info(this, "N64 Loader: Trying to loading signature file as N64sym format");
 		List<String> lines = Files.readAllLines(Paths.get(sigPath));
@@ -434,14 +480,15 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 			long address = Long.parseLong(parts[0], 16);
 			String name = parts[1];
 			if (address >= loadAddress) {
-				SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, MakeAddress(program, address), null, name,
+				SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, MakeAddress(context, address), null, name,
 						SourceType.ANALYSIS);
 				Msg.info(this, "N64 Loader: Loaded Symbol at " + String.format("0x%08X", address) + " Name=" + name);
 			}
 		}
 	}
 
-	public void ScanPatterns(byte[] rom, long loadAddress, String sigPath, Program program, TaskMonitor monitor)
+	public void ScanPatterns(ImportContext context, byte[] rom, long loadAddress, String sigPath, Program program,
+			TaskMonitor monitor)
 			throws IOException, InvalidInputException {
 		Msg.info(this, "N64 Loader: Trying to loading signature file as default format");
 		ArrayList<SigPattern> patterns = new ArrayList<SigPattern>();
@@ -466,7 +513,7 @@ public class N64LoaderWVLoader extends AbstractLibrarySupportLoader {
 				SigPattern sig = patterns.get(j);
 				if (sig.Match(rom, i)) {
 					long address = loadAddress + i - 0x1000;
-					Address addr = MakeAddress(program, address);
+					Address addr = MakeAddress(context, address);
 					if (addr != null) {
 						SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, addr, null, sig.name,
 								SourceType.ANALYSIS);

--- a/src/verification/java/n64loaderwv/LoaderIntegrationTest.java
+++ b/src/verification/java/n64loaderwv/LoaderIntegrationTest.java
@@ -1,0 +1,170 @@
+package n64loaderwv;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import ghidra.GhidraApplicationLayout;
+import ghidra.app.util.Option;
+import ghidra.app.util.bin.ByteArrayProvider;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.app.util.opinion.LoadSpec;
+import ghidra.app.util.opinion.Loader;
+import ghidra.framework.Application;
+import ghidra.framework.HeadlessGhidraApplicationConfiguration;
+import ghidra.program.database.ProgramDB;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.lang.LanguageCompilerSpecPair;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.util.task.TaskMonitor;
+
+public final class LoaderIntegrationTest {
+	public static void main(String[] args) throws Exception {
+		initializeGhidra();
+		N64LoaderWVLoader loader = new N64LoaderWVLoader();
+		try (LoadedProgram base = load(loader, N64LoaderWVLoader.BASE_RDRAM_SIZE);
+				LoadedProgram expanded = load(loader, N64LoaderWVLoader.EXPANDED_RDRAM_SIZE)) {
+			assertDumpMapping(base.program, N64LoaderWVLoader.BASE_RDRAM_SIZE);
+			assertDumpMapping(expanded.program, N64LoaderWVLoader.EXPANDED_RDRAM_SIZE);
+			assertProgramAddressIsolation(loader, base.program, expanded.program);
+		}
+		checksOverlayResolution(loader);
+	}
+
+	private static void initializeGhidra() throws Exception {
+		if (!Application.isInitialized()) {
+			File installDir = new File(System.getProperty("ghidra.install.dir"));
+			Application.initializeApplication(new GhidraApplicationLayout(installDir),
+					new HeadlessGhidraApplicationConfiguration());
+		}
+	}
+
+	private static LoadedProgram load(N64LoaderWVLoader loader, int dumpSize) throws Exception {
+		byte[] rom = new byte[0x2000];
+		rom[0] = (byte) 0x80;
+		rom[1] = 0x37;
+		rom[2] = 0x12;
+		rom[3] = 0x40;
+		rom[8] = (byte) 0x80;
+		rom[9] = 0x20;
+
+		byte[] dump = new byte[dumpSize];
+		dump[0] = 0x11;
+		dump[0x3ff] = 0x22;
+		dump[0x400] = 0x33;
+		dump[dump.length - 1] = 0x44;
+		Path dumpPath = Files.createTempFile("n64loaderwv-rdram-", ".bin");
+		Files.write(dumpPath, dump);
+
+		ByteArrayProvider provider = new ByteArrayProvider(rom);
+		Object consumer = new Object();
+		ProgramDB program = null;
+		boolean success = false;
+		try {
+			Collection<LoadSpec> specs = loader.findSupportedLoadSpecs(provider);
+			LoadSpec spec = specs.iterator().next();
+			LanguageCompilerSpecPair pair = spec.getLanguageCompilerSpec();
+			program = new ProgramDB("rdram-" + dumpSize, pair.getLanguage(), pair.getCompilerSpec(), consumer);
+			List<Option> options = loader.getDefaultOptions(provider, spec, program, true, false);
+			options.stream().filter(option -> option.getName().equals("RDRAM dump file")).findFirst().orElseThrow()
+					.setValue(dumpPath.toString());
+			Loader.ImporterSettings settings = new Loader.ImporterSettings(provider, "synthetic.z64", null, "/", false,
+					spec, options, consumer, new MessageLog(), TaskMonitor.DUMMY);
+			loader.loadInto(program, settings);
+			success = true;
+			return new LoadedProgram(program, consumer);
+		}
+		finally {
+			provider.close();
+			Files.deleteIfExists(dumpPath);
+			if (!success && program != null)
+				program.release(consumer);
+		}
+	}
+
+	private static void assertDumpMapping(ProgramDB program, int dumpSize) throws Exception {
+		MemoryBlock ivt = requireBlock(program, ".ivt");
+		MemoryBlock ram = requireBlock(program, ".ram");
+		assertBlock(ivt, 0x80000000L, N64LoaderWVLoader.INTERRUPT_VECTOR_SIZE);
+		assertBlock(ram, 0x80000400L, dumpSize - N64LoaderWVLoader.INTERRUPT_VECTOR_SIZE);
+		assertByte(program, ivt.getStart(), 0x11);
+		assertByte(program, ivt.getEnd(), 0x22);
+		assertByte(program, ram.getStart(), 0x33);
+		assertByte(program, ram.getEnd(), 0x44);
+	}
+
+	private static void assertProgramAddressIsolation(N64LoaderWVLoader loader, ProgramDB base, ProgramDB expanded) {
+		long expandedEnd = 0x807fffffL;
+		if (loader.MakeAddress(expanded, expandedEnd) == null)
+			throw new AssertionError("expanded Program lost its final RDRAM address");
+		if (loader.MakeAddress(base, expandedEnd) != null)
+			throw new AssertionError("base Program resolved an address from another import");
+	}
+
+	private static void checksOverlayResolution(N64LoaderWVLoader loader) throws Exception {
+		byte[] rom = { (byte) 0x80, 0x37, 0x12, 0x40 };
+		try (ByteArrayProvider provider = new ByteArrayProvider(rom)) {
+			LoadSpec spec = loader.findSupportedLoadSpecs(provider).iterator().next();
+			LanguageCompilerSpecPair pair = spec.getLanguageCompilerSpec();
+			Object consumer = new Object();
+			ProgramDB program = new ProgramDB("overlay-resolution", pair.getLanguage(), pair.getCompilerSpec(), consumer);
+			int transaction = program.startTransaction("create conflicting blocks");
+			boolean commit = false;
+			try {
+				N64LoaderWVLoader.ImportContext first = new N64LoaderWVLoader.ImportContext(program);
+				loader.MakeBlock(first, program, ".first", "first", 0x80000000L,
+						new ByteArrayInputStream(new byte[4]), 4, "111", null, new MessageLog(), TaskMonitor.DUMMY);
+				N64LoaderWVLoader.ImportContext second = new N64LoaderWVLoader.ImportContext(program);
+				loader.MakeBlock(second, program, ".second", "second", 0x80000000L,
+						new ByteArrayInputStream(new byte[4]), 4, "111", null, new MessageLog(), TaskMonitor.DUMMY);
+				Address resolved = loader.MakeAddress(second, 0x80000000L);
+				if (resolved == null || !resolved.getAddressSpace().isOverlaySpace())
+					throw new AssertionError("import context did not preserve overlay address-space identity");
+				if (resolved.equals(loader.MakeAddress(first, 0x80000000L)))
+					throw new AssertionError("separate import contexts resolved the same conflicting block");
+				commit = true;
+			}
+			finally {
+				program.endTransaction(transaction, commit);
+				program.release(consumer);
+			}
+		}
+	}
+
+	private static MemoryBlock requireBlock(ProgramDB program, String name) {
+		MemoryBlock block = program.getMemory().getBlock(name);
+		if (block == null)
+			throw new AssertionError("missing block " + name);
+		return block;
+	}
+
+	private static void assertBlock(MemoryBlock block, long start, long size) {
+		if (block.getStart().getOffset() != start || block.getSize() != size ||
+				block.getEnd().getOffset() != start + size - 1)
+			throw new AssertionError("unexpected mapping for " + block.getName());
+	}
+
+	private static void assertByte(ProgramDB program, Address address, int expected) throws Exception {
+		int actual = Byte.toUnsignedInt(program.getMemory().getByte(address));
+		if (actual != expected)
+			throw new AssertionError(String.format("expected %02x at %s, got %02x", expected, address, actual));
+	}
+
+	private static final class LoadedProgram implements AutoCloseable {
+		private final ProgramDB program;
+		private final Object consumer;
+
+		LoadedProgram(ProgramDB program, Object consumer) {
+			this.program = program;
+			this.consumer = consumer;
+		}
+
+		@Override
+		public void close() {
+			program.release(consumer);
+		}
+	}
+}

--- a/src/verification/java/n64loaderwv/RdramDumpSizingTest.java
+++ b/src/verification/java/n64loaderwv/RdramDumpSizingTest.java
@@ -1,0 +1,46 @@
+package n64loaderwv;
+
+import java.io.IOException;
+import java.util.List;
+
+import ghidra.app.util.Option;
+
+public final class RdramDumpSizingTest {
+	public static void main(String[] args) throws Exception {
+		accepts(N64LoaderWVLoader.BASE_RDRAM_SIZE);
+		accepts(N64LoaderWVLoader.EXPANDED_RDRAM_SIZE);
+		rejects(0);
+		rejects(N64LoaderWVLoader.BASE_RDRAM_SIZE - 1L);
+		rejects(N64LoaderWVLoader.BASE_RDRAM_SIZE + 1L);
+		rejects(N64LoaderWVLoader.EXPANDED_RDRAM_SIZE + 1L);
+		checksHeadlessArguments();
+	}
+
+	private static void accepts(int length) throws IOException {
+		if (N64LoaderWVLoader.checkedRdramDumpLength(length) != length)
+			throw new AssertionError("accepted RDRAM size changed");
+	}
+
+	private static void rejects(long length) throws Exception {
+		try {
+			N64LoaderWVLoader.checkedRdramDumpLength(length);
+			throw new AssertionError("accepted invalid RDRAM size " + length);
+		} catch (IOException expected) {
+			if (!expected.getMessage().contains("exactly 4 MiB or 8 MiB"))
+				throw new AssertionError("unexpected error message", expected);
+		}
+	}
+
+	private static void checksHeadlessArguments() {
+		List<Option> options = new N64LoaderWVLoader().getDefaultOptions(null, null, null, false, false);
+		String[] expected = {
+			"-loader-signature", "-loader-modem", "-loader-pif", "-loader-rdram"
+		};
+		if (options.size() != expected.length)
+			throw new AssertionError("unexpected loader option count");
+		for (int index = 0; index < expected.length; index++) {
+			if (!expected[index].equals(options.get(index).getArg()))
+				throw new AssertionError("missing headless argument " + expected[index]);
+		}
+	}
+}

--- a/src/verification/java/n64loaderwv/RdramDumpSizingTest.java
+++ b/src/verification/java/n64loaderwv/RdramDumpSizingTest.java
@@ -1,6 +1,8 @@
 package n64loaderwv;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import ghidra.app.util.Option;
@@ -13,7 +15,34 @@ public final class RdramDumpSizingTest {
 		rejects(N64LoaderWVLoader.BASE_RDRAM_SIZE - 1L);
 		rejects(N64LoaderWVLoader.BASE_RDRAM_SIZE + 1L);
 		rejects(N64LoaderWVLoader.EXPANDED_RDRAM_SIZE + 1L);
+		checksRamSliceLengths();
+		checksBoundedRead();
 		checksHeadlessArguments();
+	}
+
+	private static void checksRamSliceLengths() throws IOException {
+		if (N64LoaderWVLoader.rdramRamLength(N64LoaderWVLoader.BASE_RDRAM_SIZE) != 0x3ffc00)
+			throw new AssertionError("incorrect 4 MiB RAM slice length");
+		if (N64LoaderWVLoader.rdramRamLength(N64LoaderWVLoader.EXPANDED_RDRAM_SIZE) != 0x7ffc00)
+			throw new AssertionError("incorrect 8 MiB RAM slice length");
+	}
+
+	private static void checksBoundedRead() throws Exception {
+		Path path = Files.createTempFile("n64loaderwv-oversize-", ".bin");
+		try {
+			Files.write(path, new byte[N64LoaderWVLoader.EXPANDED_RDRAM_SIZE + 1]);
+			try {
+				N64LoaderWVLoader.readRdramDump(path);
+				throw new AssertionError("accepted oversized RDRAM file");
+			}
+			catch (IOException expected) {
+				if (!expected.getMessage().contains("exactly 4 MiB or 8 MiB"))
+					throw new AssertionError("unexpected oversized-file error", expected);
+			}
+		}
+		finally {
+			Files.deleteIfExists(path);
+		}
 	}
 
 	private static void accepts(int length) throws IOException {


### PR DESCRIPTION
## Summary

- map RDRAM snapshots at their exact 4 MiB or 8 MiB size instead of padding them to roughly 63 MiB
- bound snapshot reads to 8 MiB + 1 and reject malformed sizes before analysis
- expose the signature, modem, PIF, and RDRAM options to headless imports
- resolve symbols through per-import blocks, preserving overlay address spaces without shared loader state
- document direct discovery versus runtime-loaded code and add real Ghidra import regression tests

Related to #25. This fixes the snapshot-analysis path; it does **not** infer Banjo-Kazooie's compressed banks or overlay map from a retail ROM and does not close #25.

## Why

The previous RDRAM path used `Arrays.copyOfRange(..., 0x400, 0x3F00000)`, so a normal snapshot became an approximately 63 MiB RWX block. Loader instances also retained returned blocks across imports, allowing cross-Program lookup and unsynchronized mutation. The new import-scoped context caches the default address space and retains only the blocks returned for that import.

## Validation

- Ghidra 12.1.2 / JDK 21: `gradle clean check buildExtension`
- real `ProgramDB` imports verify exact `.ivt`/`.ram` bounds and sentinel bytes for both 4 MiB and 8 MiB dumps
- a forced address conflict verifies symbol resolution uses the newly created overlay block
- same-loader, two-Program isolation and bounded oversized-file rejection
- finalized integration and sizing verifiers: 10/10 consecutive clean runs
- AnalyzeHeadless with a private 4 MiB snapshot: 10/10 consecutive imports; malformed 5 MiB input rejected

The private validation ROM and snapshots are not included. This is the repository-defined extension suite, not Ghidra's upstream full test suite.
